### PR TITLE
(fix) Nullable parameter deprecation in getMiddlewareArray method - v5

### DIFF
--- a/src/Page.php
+++ b/src/Page.php
@@ -110,7 +110,7 @@ class Page
         return config('pages.flexible_config') ?? [];
     }
 
-    protected function getMiddlewareArray(PageModel $page = null)
+    protected function getMiddlewareArray(?PageModel $page = null)
     {
         $middleware = [
             config('pages.middleware')


### PR DESCRIPTION
Fixes #73

This PR fixes the nullable parameter deprecation warning in the `getMiddlewareArray` method by explicitly marking the `$page` parameter as nullable using the `?` syntax.

**Changes:**
- Updated `PageModel $page = null` to `?PageModel $page = null` in `getMiddlewareArray` method

This resolves the PHP 8.4+ deprecation warning about implicitly marking parameters as nullable.

This is the v5 fix targeting the master branch.